### PR TITLE
fix requirement type of `automod_profile`

### DIFF
--- a/experiment-rollout.js
+++ b/experiment-rollout.js
@@ -108,7 +108,7 @@ const data = {
         rolloutType: 0,
         requirements: [
             {
-                type: 1,
+                type: 0,
                 value: ['AUTOMOD_TRIGGER_USER_PROFILE'],
                 rate: 100,
                 ranges: [[0, 10000]]


### PR DESCRIPTION
i just realized it should be `0` according to [data](https://rollouts.advaith.io/#:~:text=has%20feature%20AUTOMOD_TRIGGER_USER_PROFILE-,None%3A%20100%25%20(0%20%2D%2010000),-Filter%3A%20Server)