### PR TITLE
- MPA/HSE, + Sub-Enabled server owners from priority and re-order

### DIFF
--- a/experiment-rollout.js
+++ b/experiment-rollout.js
@@ -44,26 +44,26 @@ const data = {
         experimentType: 1,
         rolloutType: 1,
         priority: [
-			{
-				status: 2,
+            {
+                status: 2,
                 name: 'Brands'
             },
             {
-				status: 2,
+                status: 2,
                 name: 'Discord Staff'
             },
-			{
-				status: 2,
-				name: 'Partnered, subscription-enabled (100USD/mo+), and verified server owners (includes some old partners + some content creators)'
-			},
-			{
-				status: 1,
-				name: 'Verified bots (Server count wins name conflicts, other ones will get their discriminator appended)'
-			},
-			{
-				status: 0,
-				name: 'Top (likely 100, by server count) bot developers'
-			},
+            {
+                status: 2,
+                name: 'Partnered, subscription-enabled (100USD/mo+), and verified server owners (includes some old partners + some content creators)'
+            },
+            {
+                status: 1,
+                name: 'Verified bots (Server count wins name conflicts, other ones will get their discriminator appended)'
+            },
+            {
+                status: 0,
+                name: 'Top (likely 100, by server count) bot developers'
+            },
             {
                 status: 0,
                 name: 'Everyone else (People who bought Nitro up to March 1, 2023 will be prioritized)'

--- a/experiment-rollout.js
+++ b/experiment-rollout.js
@@ -1,4 +1,4 @@
-const lastUpdate = '1684915255'; //Unix timestamp as seconds
+const lastUpdate = '1684919233'; //Unix timestamp in seconds
 
 const data = {
     clyde_ai: {
@@ -44,30 +44,26 @@ const data = {
         experimentType: 1,
         rolloutType: 1,
         priority: [
-            {
-                status: 1,
-                name: 'Verified bots (Server count wins name conflicts, other ones will get their discriminator appended)'
-            },
-            {
-                status: 2,
+			{
+				status: 2,
                 name: 'Brands'
             },
             {
-                status: 2,
-                name: 'Discord staff'
+				status: 2,
+                name: 'Discord Staff'
             },
-            {
-                status: 1,
-                name: 'Partnered and verified server owners (Includes old ones + some content creators)'
-            },
-            {
-                status: 1,
-                name: 'Moderator programs alumnis'
-            },
-            {
-                status: 0,
-                name: 'HypeSquad event owners'
-            },
+			{
+				status: 2,
+				name: 'Partnered, subscription-enabled (100USD/mo+), and verified server owners (includes some old partners + some content creators)'
+			},
+			{
+				status: 1,
+				name: 'Verified bots (Server count wins name conflicts, other ones will get their discriminator appended)'
+			},
+			{
+				status: 0,
+				name: 'Top (likely 100, by server count) bot developers'
+			},
             {
                 status: 0,
                 name: 'Everyone else (People who bought Nitro up to March 1, 2023 will be prioritized)'

--- a/experiment-rollout.js
+++ b/experiment-rollout.js
@@ -62,7 +62,7 @@ const data = {
             },
             {
                 status: 0,
-                name: 'Top (likely 100, by server count) bot developers (Un-confirmed)'
+                name: 'Top (likely 100, by server count) bot developers (Unconfirmed)'
             },
             {
                 status: 0,

--- a/experiment-rollout.js
+++ b/experiment-rollout.js
@@ -62,7 +62,7 @@ const data = {
             },
             {
                 status: 0,
-                name: 'Top (likely 100, by server count) bot developers'
+                name: 'Top (likely 100, by server count) bot developers (Un-confirmed)'
             },
             {
                 status: 0,


### PR DESCRIPTION
Hello,

I am the author of the Pull Request that added MPA and HSE to the Pomelo priority list. It turns out the leaked screenshot is fake, and Discord Staff have confirmed that MPA and HSE will not receive priority privately.

This PR removes MPA and HSE from the Pomelo priority list and adds the owners of subscription-enabled servers that generate at least $100/month (based on 7 different servers as the best estimate). Additionally, this PR reorders the list based on the date of rollout and includes the top 100 bot developers in the priority list.

Sorry for the false hopes.

Original PR: https://github.com/discordexperimenthub/assyst-tags/pull/6