### PR TITLE
Fixed minor typo

### DIFF
--- a/experiment-rollout/data.json
+++ b/experiment-rollout/data.json
@@ -233,7 +233,7 @@
             }
         ]
     },
-    "remove_reations_by_emoji": {
+    "remove_reactions_by_emoji": {
         "experimentType": 0,
         "rolloutType": 0,
         "rate": 100


### PR DESCRIPTION
Found a minor typo in line 236.
It was named "remove_reations_by_emoji", while, I THINK, is supposed to be named "remove_reactions_by_emoji"